### PR TITLE
Remove Zeograd website URL from Linux window title

### DIFF
--- a/osd_sdl_gfx.c
+++ b/osd_sdl_gfx.c
@@ -258,7 +258,7 @@ int osd_gfx_init(void)
     return 0;
   }
 
-  SDL_WM_SetCaption("Hu-Go! (www.zeograd.com)",NULL);	
+  SDL_WM_SetCaption("Hu-Go!",NULL);	
 
   if (option.want_fullscreen)
     SDL_ShowCursor(SDL_DISABLE);


### PR DESCRIPTION
When built on Linux, the SDL window title will be "Hu-Go! (www.zeograd.com)"

This would change the name of the window title to remove the URL, so that it reads as "Hu-Go!" for a cleaner appearance.

This is how the window appears with the changes in this commit, when using IceWM:

![image](https://github.com/user-attachments/assets/dd37ac3e-0162-4439-853b-1021f8055bc5)
