### PR TITLE
Replace Zeograd's personal email address

### DIFF
--- a/iniconfig.c
+++ b/iniconfig.c
@@ -389,7 +389,7 @@ set_arg (char nb_arg, const char *val)
 const char *argp_program_version = "Hu-Go! 2.12";
 
 //! bug report address for GNU argp function
-const char *argp_program_bug_address = "<zeograd@zeograd.com>";
+const char *argp_program_bug_address = "<https://github.com/rofl0r/hugo>";
 
 //! Program documentation
 static char doc[] =

--- a/manual.h
+++ b/manual.h
@@ -1,7 +1,8 @@
 static char manual_content[] = "\
 Hu-Go! Quickstart\n\
 \n\
-[mail:zeograd@zeograd.com||Zeograd]\n\
+GitHub: github.com/rofl0r/hugo\n\
+Originally by Zeograd: www.zeograd.com\n\
 \n\
 Table of Contents\n\
 \n\


### PR DESCRIPTION
Zeograd's personal email address is listed for bug reports or contact. Since the original project is dormant and this is a fork of the original work, these references have been replaced with the GitHub project URL.